### PR TITLE
fix: reset audio byte counter after commit

### DIFF
--- a/Server/gateway.js
+++ b/Server/gateway.js
@@ -157,11 +157,12 @@ wss.on('connection', (downstream, req) => {
       if (elapsed < CONFIG.minCommitMs) {
         setTimeout(() => {
           try { upstream.send(JSON.stringify(msg)); } catch {}
+          bytesSinceLastCommit = 0;
         }, CONFIG.minCommitMs - elapsed);
       } else {
         try { upstream.send(JSON.stringify(msg)); } catch {}
+        bytesSinceLastCommit = 0;
       }
-      bytesSinceLastCommit = 0;
       return;
     }
 


### PR DESCRIPTION
## Summary
- defer resetting `bytesSinceLastCommit` until after the commit is sent to the upstream server

## Testing
- `cd Server && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7afbe357c8323a8c5b022fbe4ec35